### PR TITLE
Only check items if the itemclass is used

### DIFF
--- a/Unfit-1.0.lua
+++ b/Unfit-1.0.lua
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/gpl-3.0.txt>.
 This file is part of Unfit.
 --]]
 
-local Lib = LibStub:NewLibrary('Unfit-1.0', 8)
+local Lib = LibStub:NewLibrary('Unfit-1.0', 9)
 if not Lib then
 	return
 end

--- a/Unfit-1.0.lua
+++ b/Unfit-1.0.lua
@@ -121,7 +121,7 @@ function Lib:IsItemUnusable(...)
 end
 
 function Lib:IsClassUnusable(class, subclass, slot)
-	if class and subclass then
+	if class and subclass and Lib.unusable[class] then
 		return slot ~= '' and Lib.unusable[class][subclass] or slot == 'INVTYPE_WEAPONOFFHAND' and Lib.cannotDual
 	end
 end


### PR DESCRIPTION
Checking `Lib.unusable[class][subclass]` would error on anything which is outside of the covered classes. Notably: bags, which bagnon checks for usability.
